### PR TITLE
Prevent restarts by comparing state better

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ Setting `listen_address` on a per service basis overrides the global `listen_add
 in the top level `nginx` config hash.
 * `listen_options`: additional listen options provided as a string,
 such as `reuseport`, to append to the listen line. (default is empty string)
-* `upstream_order`: how servers should be ordered in the `upstream` stanza. Setting to `asc` means sorting backends in ascending alphabetical order before generating stanza. `desc` means descending alphabetical order. `no_shuffle` means no shuffling or sorting. (default: `shuffle`, which results in random ordering of upstream servers)
+* `upstream_order`: how servers should be ordered in the `upstream` stanza.
+This defaults to `asc` to prevent reloads, and can be set to:
+  * `asc` sort upstreams in ascending alphabetical order.
+  * `desc` sort upstreams in descending alphabetical order.
+  * `shuffle` means random ordering of servers.
+  * `no_shuffle` means no shuffling or sorting.
 * `upstream_name`: The name of the generated nginx backend for this service
   (defaults to the service's key in the `services` section)
 

--- a/spec/lib/synapse/nginx_spec.rb
+++ b/spec/lib/synapse/nginx_spec.rb
@@ -16,6 +16,7 @@ describe Synapse::ConfigGenerator::Nginx do
     allow(mockWatcher).to receive(:config_for_generator).and_return({
       'nginx' => watcher_config
     })
+    allow(mockWatcher).to receive(:revision).and_return(1)
     mockWatcher
   end
 
@@ -28,6 +29,7 @@ describe Synapse::ConfigGenerator::Nginx do
     allow(mockWatcher).to receive(:config_for_generator).and_return({
       'nginx' => watcher_config
     })
+    allow(mockWatcher).to receive(:revision).and_return(1)
     mockWatcher
   end
 

--- a/synapse-nginx.gemspec
+++ b/synapse-nginx.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 
-  gem.add_runtime_dependency "synapse", "~> 0.14"
+  gem.add_runtime_dependency "synapse", "~> 0.14.4"
 
   gem.add_development_dependency "rake", "~> 0"
   gem.add_development_dependency "rspec", "~> 3.1"


### PR DESCRIPTION
The old restart logic assumed that every time the config file changed we
needed to restart, but the first line had the time in it, so it would
always restart.

Fix, don't do that